### PR TITLE
Start & run server - server boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+config.env

--- a/config.env
+++ b/config.env
@@ -1,1 +1,0 @@
-export COOKIE_PASSWORD=blahblahblahblahblah

--- a/config.env
+++ b/config.env
@@ -1,0 +1,1 @@
+COOKIE_PASSWORD=supersecretcookiepassword

--- a/config.env
+++ b/config.env
@@ -1,1 +1,1 @@
-COOKIE_PASSWORD=supersecretcookiepassword
+export COOKIE_PASSWORD=blahblahblahblahblah

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-// To start the server
 const server = require('./src/server.js');
 
 server.start((err) => {

--- a/index.js
+++ b/index.js
@@ -1,1 +1,7 @@
 // To start the server
+const server = require('./src/server.js');
+
+server.start((err) => {
+  if (err) { throw err; }
+  console.log(`Server is running at ${server.info.uri}`);
+});

--- a/src/rooms.js
+++ b/src/rooms.js
@@ -1,0 +1,1 @@
+const rooms = {};

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -1,0 +1,7 @@
+module.exports = {
+  method: 'GET',
+  path: '/',
+  handler: (req, reply) => {
+    reply('homepage');
+  }
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,1 +1,3 @@
-
+module.exports = [
+  require('./home')
+];

--- a/src/server.js
+++ b/src/server.js
@@ -8,8 +8,6 @@ const routes = require('./routes/index.js');
 
 const server = new Hapi.Server();
 
-const rooms = {};
-
 server.connection({
   port: process.env.PORT || 8080,
   routes: {

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,68 @@
+const Hapi = require('hapi');
+const cookieAuth = require('hapi-auth-cookie');
+const vision = require('vision');
+const inert = require('inert');
+const server = new Hapi.Server();
+const env = require('env2');
+
+// Install Environment Variables
+env('./config.env');
+
+// Set Cookie Options
+const options = {
+  password: process.env.COOKIE_PASSWORD,
+  cookie: 'livepeerscookie',
+  ttl: 24 * 60 * 60 * 1000,
+  isSecure: process.env.NODE_ENV === 'PRODUCTION',
+  isHttpOnly: false,
+  redirectTo: '/'
+};  // make this :)
+
+// Set Connection
+server.connection({
+  port: process.env.PORT || 8080,
+  routes: {
+    files: {
+      relativeTo: __dirname
+    }
+  }
+});
+
+// Register Plugins
+server.register([vision, inert, cookieAuth], (err) => {
+  if (err) { throw err; }
+
+    // Register views
+  server.views({
+    engines: {
+      hbs: require('handlebars')
+    },
+    relativeTo: __dirname,
+    path: 'views',
+    layoutPath: 'views/layout/',
+    helpersPath: 'views/helpers/',
+    layout: 'layout',
+    partialsPath: 'views/partials/'
+  });
+  server.auth.strategy('session', 'cookie', options);
+
+  const fileRoute = {
+    method: 'GET',
+    path: '/{path*}',
+    handler: {
+      directory: {
+        path: '../public'
+      }
+    }
+  };
+  const joinRoute = {
+    method: 'GET',
+    path: '/',
+    handler: (req, reply) => {
+      reply.view('join.hbs');
+    }
+  };
+  server.route([fileRoute, joinRoute]);
+});
+
+module.exports = server;

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,8 @@ const routes = require('./routes/index.js');
 
 const server = new Hapi.Server();
 
+class rooms = {};
+
 server.connection({
   port: process.env.PORT || 8080,
   routes: {

--- a/src/server.js
+++ b/src/server.js
@@ -8,7 +8,7 @@ const routes = require('./routes/index.js');
 
 const server = new Hapi.Server();
 
-class rooms = {};
+const rooms = {};
 
 server.connection({
   port: process.env.PORT || 8080,

--- a/src/server.js
+++ b/src/server.js
@@ -8,15 +8,6 @@ const routes = require('./routes/index.js');
 
 const server = new Hapi.Server();
 
-const options = {
-  password: process.env.COOKIE_PASSWORD,
-  cookie: 'livepeerscookie',
-  ttl: 24 * 60 * 60 * 1000,
-  isSecure: process.env.NODE_ENV === 'PRODUCTION',
-  isHttpOnly: false,
-  redirectTo: '/'
-};
-
 server.connection({
   port: process.env.PORT || 8080,
   routes: {
@@ -40,7 +31,17 @@ server.register([Vision, Inert, CookieAuth], (err) => {
     layout: 'layout',
     partialsPath: 'views/partials/'
   });
+
+  const options = {
+    password: process.env.COOKIE_PASSWORD,
+    cookie: 'livepeerscookie',
+    ttl: 24 * 60 * 60 * 1000,
+    isSecure: process.env.NODE_ENV === 'PRODUCTION',
+    isHttpOnly: false,
+    redirectTo: '/'
+  };
   server.auth.strategy('session', 'cookie', options);
+
   server.route(routes);
 });
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,14 +1,13 @@
 const Hapi = require('hapi');
-const cookieAuth = require('hapi-auth-cookie');
-const vision = require('vision');
-const inert = require('inert');
+const CookieAuth = require('hapi-auth-cookie');
+const Vision = require('vision');
+const Inert = require('inert');
+const Path = require('path');
+const env = require('env2')('./config.env');
+const routes = require('./routes/index.js');
+
 const server = new Hapi.Server();
-const env = require('env2');
 
-// Install Environment Variables
-env('./config.env');
-
-// Set Cookie Options
 const options = {
   password: process.env.COOKIE_PASSWORD,
   cookie: 'livepeerscookie',
@@ -16,23 +15,20 @@ const options = {
   isSecure: process.env.NODE_ENV === 'PRODUCTION',
   isHttpOnly: false,
   redirectTo: '/'
-};  // make this :)
+};
 
-// Set Connection
 server.connection({
   port: process.env.PORT || 8080,
   routes: {
     files: {
-      relativeTo: __dirname
+      relativeTo: path.join(__dirname, '../public')
     }
   }
 });
 
-// Register Plugins
-server.register([vision, inert, cookieAuth], (err) => {
+server.register([Vision, Inert, CookieAuth], (err) => {
   if (err) { throw err; }
 
-    // Register views
   server.views({
     engines: {
       hbs: require('handlebars')
@@ -45,24 +41,7 @@ server.register([vision, inert, cookieAuth], (err) => {
     partialsPath: 'views/partials/'
   });
   server.auth.strategy('session', 'cookie', options);
-
-  const fileRoute = {
-    method: 'GET',
-    path: '/{path*}',
-    handler: {
-      directory: {
-        path: '../public'
-      }
-    }
-  };
-  const joinRoute = {
-    method: 'GET',
-    path: '/',
-    handler: (req, reply) => {
-      reply.view('join.hbs');
-    }
-  };
-  server.route([fileRoute, joinRoute]);
+  server.route(routes);
 });
 
 module.exports = server;

--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,7 @@ server.connection({
   port: process.env.PORT || 8080,
   routes: {
     files: {
-      relativeTo: path.join(__dirname, '../public')
+      relativeTo: Path.join(__dirname, '../public')
     }
   }
 });


### PR DESCRIPTION
Just tidied up the boilerplate:
+ removed comments
+ put `('./config.env')` onto line where env is required
+ consistent naming convention - capitalise required modules
+ removed routes as these will sit in `routes/index.js`, added dummy route in `home.js`
+ added new `rooms` object

(Also, by resolving merge conflicts with master, `index.js` is back to starting the server)

