### PR TITLE
uncomment out partials in main.hbs

### DIFF
--- a/src/views/main.hbs
+++ b/src/views/main.hbs
@@ -46,13 +46,13 @@
     <div class="apps__av">
       <h3>(video container goes here)</h3>
       <!-- Video goes here -->
-      <!--{{> av pin=pin}} -->
+      {{> av}}
     </div>
 
     <div class="selected apps__chat">
       <h3>(chat container goes here)</h3>
       <!-- Chat goes here -->
-      <!--{{> chat }} -->
+      {{> chat }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Self explanatory, but `main.hbs` still has {{>av}} and {{>chat}} commented out, so the partials don't get injected correctly

Fixes #80